### PR TITLE
fix: Remove incorrect display of back button on events screen

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/auth/EditProfileFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/auth/EditProfileFragment.kt
@@ -170,4 +170,11 @@ class EditProfileFragment : Fragment() {
             }
         }
     }
+
+    override fun onDestroyView() {
+        val activity = activity as? AppCompatActivity
+        activity?.supportActionBar?.setDisplayHomeAsUpEnabled(false)
+        setHasOptionsMenu(false)
+        super.onDestroyView()
+    }
 }


### PR DESCRIPTION
Fixes #711 

Changes: 
Now, after pressing back to go from Edit Profile to Events, the back button will not keep displaying. 

GIF for the change:
![ezgif com-video-to-gif 7](https://user-images.githubusercontent.com/35566748/49666518-598c7280-fa7e-11e8-90c8-816df9609ff1.gif)

