### PR TITLE
fix: wrong order status

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/attendees/AttendeeFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/attendees/AttendeeFragment.kt
@@ -117,6 +117,8 @@ import java.util.Calendar
 import java.util.Currency
 import kotlin.collections.ArrayList
 
+private const val COUNT_DOWN_TIME = 15 // in minutes
+
 class AttendeeFragment : Fragment(), ComplexBackPressFragment {
 
     private lateinit var rootView: View
@@ -244,8 +246,6 @@ class AttendeeFragment : Fragment(), ComplexBackPressFragment {
             .setTitle(getString(R.string.cancel_order))
             .setMessage(getString(R.string.cancel_order_message))
             .setPositiveButton(getString(R.string.continue_string)) { _, _ ->
-                if (!attendeeViewModel.orderCreatedSuccess)
-                    attendeeViewModel.cancelPendingOrder()
                 findNavController(rootView).popBackStack()
             }
             .setNegativeButton(getString(R.string.cancel)) { dialog, _ ->
@@ -288,7 +288,7 @@ class AttendeeFragment : Fragment(), ComplexBackPressFragment {
 
         val currentPendingOrder = attendeeViewModel.pendingOrder.value
         if (currentPendingOrder == null) {
-            attendeeViewModel.createPendingOrder(safeArgs.eventId)
+            attendeeViewModel.initializeOrder(safeArgs.eventId)
         }
     }
 
@@ -297,12 +297,10 @@ class AttendeeFragment : Fragment(), ComplexBackPressFragment {
         rootView.timeoutInfoTextView.text =
             getString(R.string.ticket_timeout_info_message, event.orderExpiryTime.toString())
 
-        val timeLeft: Long = if (attendeeViewModel.timeout == -1L) event.orderExpiryTime * 60 * 1000L
+        val timeLeft: Long = if (attendeeViewModel.timeout == -1L) COUNT_DOWN_TIME * 60 * 1000L
                                 else attendeeViewModel.timeout
         timer = object : CountDownTimer(timeLeft, 1000) {
             override fun onFinish() {
-                if (!attendeeViewModel.orderCreatedSuccess)
-                    attendeeViewModel.cancelPendingOrder()
                 findNavController(rootView).navigate(AttendeeFragmentDirections
                     .actionAttendeeToTicketPop(safeArgs.eventId, safeArgs.currency, true))
             }

--- a/app/src/main/java/org/fossasia/openevent/general/attendees/AttendeeViewModel.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/attendees/AttendeeViewModel.kt
@@ -30,6 +30,7 @@ const val ORDER_STATUS_PENDING = "pending"
 const val ORDER_STATUS_COMPLETED = "completed"
 const val ORDER_STATUS_PLACED = "placed"
 const val ORDER_STATUS_CANCELLED = "cancelled"
+const val ORDER_STATUS_INITIALIZING = "initializing"
 const val PAYMENT_MODE_FREE = "free"
 const val PAYMENT_MODE_BANK = "bank"
 const val PAYMENT_MODE_ONSITE = "onsite"
@@ -95,7 +96,6 @@ class AttendeeViewModel(
     var yearSelectedPosition: Int = 0
     var paymentCurrency: String = ""
     var timeout: Long = -1L
-    var orderCreatedSuccess = false
     var ticketDetailsVisible = false
     var billingEnabled = false
 
@@ -147,24 +147,8 @@ class AttendeeViewModel(
             })
     }
 
-    fun cancelPendingOrder() {
-        var order = mutablePendingOrder.value
-        val identifier: String? = orderIdentifier
-        if (order == null || identifier == null) return
-
-        order = order.copy(status = ORDER_STATUS_CANCELLED)
-        compositeDisposable += orderService.editOrder(identifier, order)
-            .withDefaultSchedulers()
-            .subscribe({
-                Timber.d("Pending order cancelled")
-                mutableMessage.value = resource.getString(R.string.pending_order_cancelled_message)
-            }, {
-                Timber.e("Fail on cancelling order")
-            })
-    }
-
-    fun createPendingOrder(eventId: Long) {
-        val emptyOrder = Order(id = getId(), status = ORDER_STATUS_PENDING, event = EventId(eventId))
+    fun initializeOrder(eventId: Long) {
+        val emptyOrder = Order(id = getId(), status = ORDER_STATUS_INITIALIZING, event = EventId(eventId))
 
         compositeDisposable += orderService.placeOrder(emptyOrder)
             .withDefaultSchedulers()


### PR DESCRIPTION
Details:
- When initializing an order, the order status used is "INITIALIZING", not "PENDING".
- Don't have to cancel order when time counter goes down as the server automatically hanndle it

Fixes: #2026
