### PR TITLE
fix: Illogical information displayed in Ticket and Event section

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/attendees/AttendeeService.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/attendees/AttendeeService.kt
@@ -28,7 +28,17 @@ class AttendeeService(
     }
 
     fun getCustomFormsForAttendees(id: Long): Single<List<CustomForm>> {
-        val filter = "[{\"name\":\"form\",\"op\":\"eq\",\"val\":\"attendee\"}]"
+        val filter = """[{
+                |   'and':[{
+                |       'name':'form',
+                |       'op':'eq',
+                |       'val':'attendee'
+                |    },{
+                |       'name':'is-included',
+                |       'op':'eq',
+                |       'val':true
+                |    }]
+                |}]""".trimMargin().replace("'", "\"")
         return attendeeApi.getCustomFormsForAttendees(id, filter)
     }
 }

--- a/app/src/main/java/org/fossasia/openevent/general/attendees/AttendeeViewHolder.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/attendees/AttendeeViewHolder.kt
@@ -5,6 +5,9 @@ import android.text.Editable
 import android.text.InputType
 import android.text.SpannableStringBuilder
 import android.text.TextWatcher
+import android.view.View
+import android.widget.AdapterView
+import android.widget.ArrayAdapter
 import androidx.core.view.isVisible
 import com.google.android.material.textfield.TextInputEditText
 import com.google.android.material.textfield.TextInputLayout
@@ -45,15 +48,18 @@ import kotlinx.android.synthetic.main.item_attendee.view.homeAddress
 import kotlinx.android.synthetic.main.item_attendee.view.cityLayout
 import kotlinx.android.synthetic.main.item_attendee.view.city
 import kotlinx.android.synthetic.main.item_attendee.view.genderLayout
-import kotlinx.android.synthetic.main.item_attendee.view.gender
+import kotlinx.android.synthetic.main.item_attendee.view.genderText
+import kotlinx.android.synthetic.main.item_attendee.view.genderSpinner
 import kotlinx.android.synthetic.main.item_attendee.view.company
 import kotlinx.android.synthetic.main.item_attendee.view.companyLayout
 import kotlinx.android.synthetic.main.item_attendee.view.countryLayout
 import kotlinx.android.synthetic.main.item_attendee.view.country
 import kotlinx.android.synthetic.main.item_attendee.view.jobTitleLayout
 import kotlinx.android.synthetic.main.item_attendee.view.jobTitle
+import org.fossasia.openevent.general.R
 import org.fossasia.openevent.general.attendees.forms.CustomForm
 import org.fossasia.openevent.general.attendees.forms.FormIdentifier
+import org.fossasia.openevent.general.data.Resource
 import org.fossasia.openevent.general.databinding.ItemAttendeeBinding
 import org.fossasia.openevent.general.event.EventId
 import org.fossasia.openevent.general.ticket.Ticket
@@ -66,6 +72,7 @@ import org.fossasia.openevent.general.utils.setRequired
 import org.fossasia.openevent.general.utils.nullToEmpty
 
 class AttendeeViewHolder(private val binding: ItemAttendeeBinding) : RecyclerView.ViewHolder(binding.root) {
+    private val resource = Resource()
     private val requiredList = mutableListOf<TextInputEditText>()
     var onAttendeeDetailChanged: AttendeeDetailChangeListener? = null
 
@@ -101,32 +108,7 @@ class AttendeeViewHolder(private val binding: ItemAttendeeBinding) : RecyclerVie
         }
         val textWatcher = object : TextWatcher {
             override fun afterTextChanged(s: Editable?) {
-                val newAttendee = Attendee(
-                    id = attendee.id,
-                    firstname = itemView.firstName.text.toString(),
-                    lastname = itemView.lastName.text.toString(),
-                    email = itemView.email.text.toString(),
-                    address = itemView.address.text.toString().emptyToNull(),
-                    city = itemView.city.text.toString().emptyToNull(),
-                    state = itemView.state.text.toString().emptyToNull(),
-                    country = itemView.country.text.toString().emptyToNull(),
-                    jobTitle = itemView.jobTitle.text.toString().emptyToNull(),
-                    phone = itemView.phone.text.toString().emptyToNull(),
-                    taxBusinessInfo = itemView.taxBusinessInfo.text.toString().emptyToNull(),
-                    billingAddress = itemView.attendeeBillingAddress.text.toString().emptyToNull(),
-                    homeAddress = itemView.homeAddress.text.toString().emptyToNull(),
-                    shippingAddress = itemView.shippingAddress.text.toString().emptyToNull(),
-                    company = itemView.company.text.toString().emptyToNull(),
-                    workAddress = itemView.workAddress.text.toString().emptyToNull(),
-                    workPhone = itemView.workPhone.text.toString().emptyToNull(),
-                    website = itemView.website.text.toString().emptyToNull(),
-                    blog = itemView.blog.text.toString().emptyToNull(),
-                    twitter = itemView.twitter.text.toString().emptyToNull(),
-                    facebook = itemView.facebook.text.toString().emptyToNull(),
-                    github = itemView.github.text.toString().emptyToNull(),
-                    gender = itemView.gender.text.toString().emptyToNull(),
-                    ticket = TicketId(ticket.id.toLong()),
-                    event = EventId(eventId))
+                val newAttendee = getAttendeeInformation(attendee.id, ticket, eventId)
                 onAttendeeDetailChanged?.onAttendeeDetailChanged(newAttendee, position)
             }
 
@@ -134,6 +116,7 @@ class AttendeeViewHolder(private val binding: ItemAttendeeBinding) : RecyclerVie
             override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) { /*Do nothing*/ }
         }
         requiredList.clear()
+        setupGendersSpinner(attendee, ticket, eventId, position)
         customForm.forEach { form ->
             setupCustomFormWithFields(form, textWatcher)
         }
@@ -183,9 +166,33 @@ class AttendeeViewHolder(private val binding: ItemAttendeeBinding) : RecyclerVie
                 setupField(itemView.companyLayout, itemView.company, form.isRequired, textWatcher)
             FormIdentifier.GITHUB ->
                 setupField(itemView.githubLayout, itemView.github, form.isRequired, textWatcher)
-            FormIdentifier.GENDER ->
-                setupField(itemView.genderLayout, itemView.gender, form.isRequired, textWatcher)
+            FormIdentifier.GENDER -> {
+                itemView.genderLayout.isVisible = true
+                if (form.isRequired) {
+                    itemView.genderText.text = "${resource.getString(R.string.gender)}*"
+                }
+            }
             else -> return
+        }
+    }
+
+    private fun setupGendersSpinner(attendee: Attendee, ticket: Ticket, eventId: Long, position: Int) {
+        val genders = mutableListOf(resource.getString(R.string.male),
+            resource.getString(R.string.female), resource.getString(R.string.others))
+        itemView.genderSpinner.adapter =
+            ArrayAdapter(itemView.context, android.R.layout.simple_spinner_dropdown_item, genders)
+
+        val genderSelected = genders.indexOf(attendee.gender)
+        if (genderSelected != -1)
+            itemView.genderSpinner.setSelection(genderSelected)
+
+        itemView.genderSpinner.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
+            override fun onNothingSelected(parent: AdapterView<*>?) { /* Do Nothing */ }
+
+            override fun onItemSelected(parent: AdapterView<*>?, view: View?, p: Int, id: Long) {
+                val newAttendee = getAttendeeInformation(attendee.id, ticket, eventId)
+                onAttendeeDetailChanged?.onAttendeeDetailChanged(newAttendee, position)
+            }
         }
     }
 
@@ -216,5 +223,34 @@ class AttendeeViewHolder(private val binding: ItemAttendeeBinding) : RecyclerVie
                 (it.inputType == InputType.TYPE_TEXT_VARIATION_URI && !it.checkValidURI())) return false
         }
         return true
+    }
+
+    private fun getAttendeeInformation(id: Long, ticket: Ticket, eventId: Long): Attendee {
+        return Attendee(
+            id = id,
+            firstname = itemView.firstName.text.toString(),
+            lastname = itemView.lastName.text.toString(),
+            email = itemView.email.text.toString(),
+            address = itemView.address.text.toString().emptyToNull(),
+            city = itemView.city.text.toString().emptyToNull(),
+            state = itemView.state.text.toString().emptyToNull(),
+            country = itemView.country.text.toString().emptyToNull(),
+            jobTitle = itemView.jobTitle.text.toString().emptyToNull(),
+            phone = itemView.phone.text.toString().emptyToNull(),
+            taxBusinessInfo = itemView.taxBusinessInfo.text.toString().emptyToNull(),
+            billingAddress = itemView.attendeeBillingAddress.text.toString().emptyToNull(),
+            homeAddress = itemView.homeAddress.text.toString().emptyToNull(),
+            shippingAddress = itemView.shippingAddress.text.toString().emptyToNull(),
+            company = itemView.company.text.toString().emptyToNull(),
+            workAddress = itemView.workAddress.text.toString().emptyToNull(),
+            workPhone = itemView.workPhone.text.toString().emptyToNull(),
+            website = itemView.website.text.toString().emptyToNull(),
+            blog = itemView.blog.text.toString().emptyToNull(),
+            twitter = itemView.twitter.text.toString().emptyToNull(),
+            facebook = itemView.facebook.text.toString().emptyToNull(),
+            github = itemView.github.text.toString().emptyToNull(),
+            gender = itemView.genderSpinner.selectedItem.toString(),
+            ticket = TicketId(ticket.id.toLong()),
+            event = EventId(eventId))
     }
 }

--- a/app/src/main/java/org/fossasia/openevent/general/ticket/TicketDetailsViewHolder.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/ticket/TicketDetailsViewHolder.kt
@@ -22,6 +22,7 @@ class TicketDetailsViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView
             }
             TICKET_TYPE_FREE -> {
                 itemView.price.text = resource.getString(R.string.free)
+                itemView.subTotal.text = "${eventCurrency}0.00"
             }
             TICKET_TYPE_PAID -> {
                 itemView.price.text = "$eventCurrency${ticket.price}"

--- a/app/src/main/java/org/fossasia/openevent/general/ticket/TicketsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/ticket/TicketsFragment.kt
@@ -39,7 +39,6 @@ import org.fossasia.openevent.general.utils.Utils.progressDialog
 import org.fossasia.openevent.general.utils.Utils.show
 import org.fossasia.openevent.general.utils.Utils.hideSoftKeyboard
 import org.fossasia.openevent.general.utils.extensions.nonNull
-import org.fossasia.openevent.general.utils.nullToEmpty
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.fossasia.openevent.general.utils.Utils.setToolbar
 import org.jetbrains.anko.design.longSnackbar
@@ -277,7 +276,13 @@ class TicketsFragment : Fragment() {
 
     private fun loadEventDetails(event: Event) {
         rootView.eventName.text = event.name
-        rootView.organizerName.text = "by ${event.ownerName.nullToEmpty()}"
+        val organizerName = event.ownerName
+        if (organizerName == null) {
+            rootView.organizerName.isVisible = false
+        } else {
+            rootView.organizerName.isVisible = true
+            rootView.organizerName.text = "by $organizerName"
+        }
         val startsAt = EventUtils.getEventDateTime(event.startsAt, event.timezone)
         val endsAt = EventUtils.getEventDateTime(event.endsAt, event.timezone)
         rootView.time.text = EventUtils.getFormattedDateTimeRangeDetailed(startsAt, endsAt)

--- a/app/src/main/res/layout/item_attendee.xml
+++ b/app/src/main/res/layout/item_attendee.xml
@@ -392,22 +392,28 @@
                 android:text="@{attendee.github}"
                 android:inputType="textUri"/>
         </com.google.android.material.textfield.TextInputLayout>
-        <com.google.android.material.textfield.TextInputLayout
-            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.Dense"
+
+        <LinearLayout
             android:id="@+id/genderLayout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginBottom="@dimen/padding_medium"
             android:layout_marginTop="@dimen/padding_medium"
-            android:hint="@string/gender"
+            android:orientation="horizontal"
+            android:padding="@dimen/padding_medium"
             android:visibility="gone"
             tools:visibility="visible">
-
-            <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/gender"
-                android:layout_width="match_parent"
+            <TextView
+                android:id="@+id/genderText"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="@{attendee.gender}"/>
-        </com.google.android.material.textfield.TextInputLayout>
+                android:layout_marginEnd="@dimen/layout_margin_large"
+                android:textSize="@dimen/text_size_large"
+                android:text="@string/gender"/>
+            <androidx.appcompat.widget.AppCompatSpinner
+                android:id="@+id/genderSpinner"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"/>
+        </LinearLayout>
     </LinearLayout>
 </layout>

--- a/app/src/main/res/layout/item_card_order_details.xml
+++ b/app/src/main/res/layout/item_card_order_details.xml
@@ -296,16 +296,17 @@
                 android:layout_height="wrap_content"
                 android:text="@string/event_summary"
                 android:textSize="@dimen/text_size_medium"
-                tools:text="@string/event_summary" />
+                app:hideIfEmpty="@{event.description}"/>
 
             <TextView
                 android:id="@+id/eventSummary"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:ellipsize="end"
-                android:lines="2"
+                android:maxLines="2"
                 android:textColor="@color/black"
                 android:textSize="@dimen/text_size_large"
+                app:hideIfEmpty="@{event.description}"
                 app:strippedHtml="@{event.description}"
                 tools:text="@string/event_summary_preview" />
 
@@ -337,6 +338,7 @@
                 android:textColor="@color/black"
                 android:textSize="@dimen/text_size_large"
                 android:text="@{event.ownerName}"
+                app:hideIfEmpty="@{event.ownerName}"
                 tools:text="@string/organizer_preview" />
 
             <Button

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -434,6 +434,12 @@
     <string name="placed_orders">Placed Orders</string>
     <string name="pending_orders">Pending Orders</string>
     <string name="order_status">Order Status</string>
+    <string name="pay_now">Pay Now</string>
+    <string name="cancel_order_button">Yes, cancel this order</string>
+    <string name="continue_order_button">No, continue</string>
+    <string name="others">Others</string>
+    <string name="female">Female</string>
+    <string name="male">Male</string>
     <plurals name="ordersQuantity">
         <item quantity="one">%1$s ticket</item>
         <item quantity="other">%1$s tickets</item>


### PR DESCRIPTION
Details:
- Gender picker should be turned into a spinner instead of edit text
- Empty white unused space about event detail of order detail section
- Empty organizer name in Tickets Fragment
- Confusing Cancel/Continue Order
Subtotal/Total ticket price in AttendeeFragment
- Display button "Register", "Pay now"
- Fix filter for custom form

Fixes: #2126 

Screenshots for the change:
<img src="https://i.ibb.co/ZT40D0y/66726362-2098927290236570-7374471878162776064-n.jpg" width="350">