### PR TITLE
chore: Bump nav_version and set jvm target to 1.8

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -94,12 +94,16 @@ android {
     }
     lintOptions {
         disable 'MissingTranslation'
+        warning 'InvalidPackage'
     }
     androidExtensions {
         experimental = true
     }
     aaptOptions {
         cruncherEnabled = false
+    }
+    kotlinOptions {
+        jvmTarget = "1.8"
     }
 }
 
@@ -122,7 +126,7 @@ dependencies {
     def roomVersion = "2.1.0"
     def ktx_version = "1.0.0"
     def ktx2_version = "2.0.0"
-    def nav_version = "2.1.0-alpha06"
+    def nav_version = "2.1.0-beta01"
     def anko_version = "0.10.8"
     def paging_version = "2.1.0"
 


### PR DESCRIPTION
Fixes #2141 

Reference issue: https://issuetracker.google.com/issues/137782949
Solution: https://issuetracker.google.com/issues/137268935