### PR TITLE
fix: Event time, price and UI for tickets

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/attendees/AttendeeFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/attendees/AttendeeFragment.kt
@@ -800,7 +800,6 @@ class AttendeeFragment : Fragment(), ComplexBackPressFragment {
     }
 
     private fun loadEventDetailsUI(event: Event) {
-        val dateString = StringBuilder()
         val startsAt = EventUtils.getEventDateTime(event.startsAt, event.timezone)
         val endsAt = EventUtils.getEventDateTime(event.endsAt, event.timezone)
 
@@ -808,27 +807,11 @@ class AttendeeFragment : Fragment(), ComplexBackPressFragment {
         ticketsRecyclerAdapter.setCurrency(attendeeViewModel.paymentCurrency)
 
         rootView.eventName.text = event.name
-        val total = if (safeArgs.amount > 0) "${attendeeViewModel.paymentCurrency}${safeArgs.amount}"
+        val total = if (safeArgs.amount > 0) "${attendeeViewModel.paymentCurrency} ${"%.2f".format(safeArgs.amount)}"
                 else getString(R.string.free)
         rootView.amount.text = "Total: $total"
 
-        val startDate = EventUtils.getFormattedDate(startsAt)
-        val endDate = EventUtils.getFormattedDate(endsAt)
-        dateString.append(startDate)
-        if (startDate == endDate) {
-            dateString.append(" • ")
-                .append(EventUtils.getFormattedTime(startsAt))
-                .append(" - ")
-                .append(EventUtils.getFormattedTime(endsAt))
-        } else {
-            dateString.append(" - ")
-                .append(EventUtils.getFormattedTime(startsAt))
-                .append(" • ")
-                .append(endDate)
-                .append(" - ")
-                .append(EventUtils.getFormattedTime(endsAt))
-        }
-        rootView.time.text = dateString
+        rootView.time.text = EventUtils.getFormattedDateTimeRangeDetailed(startsAt, endsAt)
     }
 
     private fun loadUserUI(user: User) {

--- a/app/src/main/java/org/fossasia/openevent/general/event/EventDetailsViewModel.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventDetailsViewModel.kt
@@ -307,7 +307,7 @@ class EventDetailsViewModel(
             else {
                 range.append(paymentCurrency)
                 range.append(" ")
-                range.append(minPrice)
+                range.append("%.2f".format(minPrice))
             }
         } else {
             if (minPrice == 0f)
@@ -315,12 +315,12 @@ class EventDetailsViewModel(
             else {
                 range.append(paymentCurrency)
                 range.append(" ")
-                range.append(minPrice)
+                range.append("%.2f".format(minPrice))
             }
             range.append(" - ")
             range.append(paymentCurrency)
             range.append(" ")
-            range.append(maxPrice)
+            range.append("%.2f".format(maxPrice))
         }
         mutablePriceRange.value = range.toString()
     }

--- a/app/src/main/java/org/fossasia/openevent/general/ticket/TicketDetailsViewHolder.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/ticket/TicketDetailsViewHolder.kt
@@ -18,16 +18,16 @@ class TicketDetailsViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView
         when (ticket.type) {
             TICKET_TYPE_DONATION -> {
                 itemView.price.text = resource.getString(R.string.donation)
-                itemView.subTotal.text = "$eventCurrency$donationAmount"
+                itemView.subTotal.text = "$eventCurrency${"%2.f".format(donationAmount)}"
             }
             TICKET_TYPE_FREE -> {
                 itemView.price.text = resource.getString(R.string.free)
                 itemView.subTotal.text = "${eventCurrency}0.00"
             }
             TICKET_TYPE_PAID -> {
-                itemView.price.text = "$eventCurrency${ticket.price}"
+                itemView.price.text = "$eventCurrency${"%.2f".format(ticket.price)}"
                 val subTotal: Float? = ticket.price.times(ticketQuantity)
-                itemView.subTotal.text = "$eventCurrency$subTotal"
+                itemView.subTotal.text = "$eventCurrency${"%.2f".format(subTotal)}"
             }
         }
 

--- a/app/src/main/java/org/fossasia/openevent/general/ticket/TicketViewHolder.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/ticket/TicketViewHolder.kt
@@ -90,7 +90,7 @@ class TicketViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
                 itemView.donationInput.isVisible = false
             }
             TICKET_TYPE_PAID -> {
-                itemView.price.text = "$eventCurrency${ticket.price}"
+                itemView.price.text = "$eventCurrency${"%.2f".format(ticket.price)}"
                 itemView.priceSection.isVisible = true
                 itemView.donationInput.isVisible = false
             }
@@ -107,12 +107,12 @@ class TicketViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
             itemView.description.text = ticket.description
         }
 
-        if (discountCode?.value != null && ticket.price != null && ticket.price != 0.toFloat()) {
+        if (discountCode?.value != null && ticket.price != 0.toFloat()) {
             itemView.discountPrice.visibility = View.VISIBLE
             itemView.price.paintFlags = Paint.STRIKE_THRU_TEXT_FLAG
             itemView.discountPrice.text =
                 if (discountCode.type == AMOUNT) "$eventCurrency${ticket.price - discountCode.value}"
-                else "$eventCurrency${ticket.price - (ticket.price * discountCode.value / 100)}"
+                else "$eventCurrency${"%.2f".format(ticket.price - (ticket.price * discountCode.value / 100))}"
         }
     }
 

--- a/app/src/main/res/layout/item_ticket.xml
+++ b/app/src/main/res/layout/item_ticket.xml
@@ -23,6 +23,7 @@
         android:orientation="vertical">
         <TextView
             android:id="@+id/ticketName"
+            android:paddingEnd="@dimen/padding_medium"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             tools:text="Google I/O" />

--- a/app/src/main/res/layout/item_ticket_details.xml
+++ b/app/src/main/res/layout/item_ticket_details.xml
@@ -11,6 +11,7 @@
     <TextView
         android:id="@+id/ticketName"
         android:layout_width="@dimen/layout_margin_none"
+        android:paddingEnd="@dimen/padding_medium"
         android:layout_height="wrap_content"
         android:layout_weight="2"
         tools:text="Google I/O" />
@@ -20,12 +21,13 @@
         android:layout_width="@dimen/layout_margin_none"
         android:layout_height="wrap_content"
         android:layout_weight="1"
-        android:maxLines="1"
+        android:maxLines="2"
         android:ellipsize="end"
         tools:text="$25" />
 
     <TextView
         android:id="@+id/qty"
+        android:paddingStart="@dimen/padding_medium"
         android:layout_width="@dimen/layout_margin_none"
         android:layout_height="wrap_content"
         android:layout_weight="1"


### PR DESCRIPTION
Fixes #2119 

- Set margin b/w ticket name and price
- Display tickets price with two decimal places
- Fix event time in tickets fragment

<p align="center">
<img src="https://user-images.githubusercontent.com/27783786/61574351-2615ca00-aadc-11e9-9b69-79ca6dd337ab.png" height = "380" width="200"> 
<img src="https://user-images.githubusercontent.com/27783786/61574352-26ae6080-aadc-11e9-915d-a92a5b0960bb.png" height = "380" width="200"> 
<img src="https://user-images.githubusercontent.com/27783786/61574353-26ae6080-aadc-11e9-8ad4-39f67937045a.png" height = "380" width="200"> 
</p>