### PR TITLE
Revert "chore(deps): bump jackson-module-kotlin from 2.9.6 to 2.10.0.pr1"

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -170,7 +170,7 @@ dependencies {
     implementation 'com.jakewharton.timber:timber:4.7.1'
     implementation 'com.jakewharton.threetenabp:threetenabp:1.2.1'
 
-    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:2.10.0.pr1"
+    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:2.9.6"
     implementation 'com.github.jasminb:jsonapi-converter:0.9'
     implementation 'com.squareup.okhttp3:logging-interceptor:4.0.1'
     implementation 'com.squareup.retrofit2:retrofit:2.6.0'


### PR DESCRIPTION
Reverts fossasia/open-event-attendee-android#2157
Fixes #2159 