### PR TITLE
chore: Bump stripe from 10.4.3 to 11.0.5 and fix errors

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -192,7 +192,7 @@ dependencies {
     implementation 'com.squareup.picasso:picasso:2.71828'
 
     // Stripe
-    implementation 'com.stripe:stripe-android:10.4.3'
+    implementation 'com.stripe:stripe-android:11.0.5'
 
     // QR Code
     implementation 'com.journeyapps:zxing-android-embedded:3.6.0'

--- a/app/src/main/java/org/fossasia/openevent/general/attendees/AttendeeFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/attendees/AttendeeFragment.kt
@@ -27,7 +27,6 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.navigation.Navigation.findNavController
 import androidx.navigation.fragment.navArgs
 import com.stripe.android.Stripe
-import com.stripe.android.TokenCallback
 import com.stripe.android.model.Card
 import com.stripe.android.model.Token
 import com.paypal.android.sdk.payments.PayPalService
@@ -36,6 +35,7 @@ import com.paypal.android.sdk.payments.PayPalPayment
 import com.paypal.android.sdk.payments.ShippingAddress
 import com.paypal.android.sdk.payments.PaymentActivity
 import com.paypal.android.sdk.payments.PaymentConfirmation
+import com.stripe.android.ApiResultCallback
 import java.math.BigDecimal
 import kotlinx.android.synthetic.main.fragment_attendee.view.cvc
 import kotlinx.android.synthetic.main.fragment_attendee.view.email
@@ -871,8 +871,8 @@ class AttendeeFragment : Fragment(), ComplexBackPressFragment {
     }
 
     private fun sendToken(card: Card) {
-        Stripe(requireContext())
-            .createToken(card, BuildConfig.STRIPE_API_KEY, object : TokenCallback {
+        Stripe(requireContext(), BuildConfig.STRIPE_API_KEY)
+            .createToken(card, object : ApiResultCallback<Token> {
                 override fun onSuccess(token: Token) {
                     val charge = Charge(attendeeViewModel.getId().toInt(), token.id, null)
                     attendeeViewModel.chargeOrder(charge)


### PR DESCRIPTION
Fixes #2341 
Fixes #2342 
Fixes #2343 
Changes: Bump the version of stripe-android from 10.4.3 to 11.0.5

