### PR TITLE
fix: Use event ID in favorite remove API call

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/event/EventService.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventService.kt
@@ -148,7 +148,7 @@ class EventService(
         }
 
     fun removeFavorite(favoriteEvent: FavoriteEvent, event: Event): Completable =
-        favoriteEventApi.removeFavorite(favoriteEvent.id).andThen {
+        favoriteEventApi.removeFavorite(event.id).andThen {
             event.favorite = false
             event.favoriteEventId = null
             eventDao.insertEvent(event)


### PR DESCRIPTION
Fixes #2183 

Changes: [**Before** - for removing favourite event it was passing  favoriteEventId so that it was showing error  "Object not found" 
**After** - In open-event-api-dev.herokuapp for deleteing a favourite event it is expecting event.id , So I change favouriteEventId to event.id And now it is able to remove favourite events successfully. ]

Screenshots for the change: 
![fix2183](https://user-images.githubusercontent.com/43692789/65023889-67e2b580-d951-11e9-9d78-6e58f25ef36b.png)

![3arjwd](https://user-images.githubusercontent.com/43692789/65024400-6e256180-d952-11e9-900d-5d1777c94de2.gif)

