### PR TITLE
fix: Notification dot visibility logic

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/event/EventsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventsFragment.kt
@@ -143,8 +143,6 @@ class EventsFragment : Fragment(), BottomIconDoubleClick {
 
         rootView.notification.isVisible = eventsViewModel.isLoggedIn()
         rootView.notificationToolbar.isVisible = eventsViewModel.isLoggedIn()
-        rootView.newNotificationDot.isVisible = eventsViewModel.isLoggedIn()
-        rootView.newNotificationDotToolbar.isVisible = eventsViewModel.isLoggedIn()
 
         eventsViewModel.loadLocation()
         if (rootView.locationTextView.text == getString(R.string.enter_location)) {


### PR DESCRIPTION
Fixes #2357 

Changes: In EventsFragment, the notification dot visibility was directly dependent on the logged-in status of the user and also on the observer in the StartupViewModel. So, I have removed the code responsible for setting the visibility based on logged-in status. Now, the dot only appears when there is a new notification.

Screenshots for the change:
![ezgif-3-280153746787](https://user-images.githubusercontent.com/31654207/66333625-0660a600-e955-11e9-8b80-8357104c132c.gif)