### PR TITLE
fix: Similar events collapsing

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/event/EventDetailsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventDetailsFragment.kt
@@ -387,7 +387,7 @@ class EventDetailsFragment : Fragment() {
                     if (!similarEventsAdapter.currentList.isNullOrEmpty()) {
                         hasSimilarEvents = true
                     }
-                    rootView.similarEventsContainer.isVisible =  hasSimilarEvents
+                    rootView.similarEventsContainer.isVisible = hasSimilarEvents
                 }
             })
 

--- a/app/src/main/java/org/fossasia/openevent/general/event/EventDetailsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventDetailsFragment.kt
@@ -103,6 +103,7 @@ class EventDetailsFragment : Fragment() {
     private val sessionsAdapter = SessionRecyclerAdapter()
     private val socialLinkAdapter = SocialLinksRecyclerAdapter()
     private val similarEventsAdapter = SimilarEventsListAdapter()
+    private var hasSimilarEvents: Boolean = false
 
     private lateinit var rootView: View
     private lateinit var binding: FragmentEventBinding
@@ -383,7 +384,10 @@ class EventDetailsFragment : Fragment() {
                     rootView.similarEventsContainer.isVisible = true
                 } else {
                     rootView.shimmerSimilarEvents.stopShimmer()
-                    rootView.similarEventsContainer.isVisible = similarEventsAdapter.currentList?.isEmpty() ?: true
+                    if (!similarEventsAdapter.currentList?.isEmpty()!!) {
+                        hasSimilarEvents = true
+                    }
+                    rootView.similarEventsContainer.isVisible =  hasSimilarEvents
                 }
             })
 

--- a/app/src/main/java/org/fossasia/openevent/general/event/EventDetailsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventDetailsFragment.kt
@@ -384,7 +384,7 @@ class EventDetailsFragment : Fragment() {
                     rootView.similarEventsContainer.isVisible = true
                 } else {
                     rootView.shimmerSimilarEvents.stopShimmer()
-                    if (!similarEventsAdapter.currentList?.isEmpty()!!) {
+                    if (!similarEventsAdapter.currentList.isNullOrEmpty()) {
                         hasSimilarEvents = true
                     }
                     rootView.similarEventsContainer.isVisible =  hasSimilarEvents


### PR DESCRIPTION
Fixes #2390 

Changes: 
Previously the visibility of the container layout was dependent on the size of the list fetched from the API. So, whenever the list reaches the end of the pagination, due to size 0, the visibility of the layout was set as GONE. Now, I have used a boolean hasSimiliarEvents (initially false) which get updated depending on the size of the list and container layout's visibility depends on this variable. So, even if there are events on any page the variable will be set as true otherwise false. This resolved the issue.

Screenshots for the change:
![ezgif-1-c507beb61fa8](https://user-images.githubusercontent.com/31654207/66715968-fe868300-ede6-11e9-9f28-aff7d970295d.gif)
