### PR TITLE
feat: Remove useless native binaries from paypal SDK (#2426)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -92,8 +92,31 @@ android {
     testOptions {
         unitTests.returnDefaultValues = true
     }
+    // Exclusions added for Paypal SDK
     packagingOptions {
         pickFirst 'kotlin/**'
+        exclude 'lib/arm64-v8a/libcardioDecider.so'
+        exclude 'lib/arm64-v8a/libcardioRecognizer.so'
+        exclude 'lib/arm64-v8a/libcardioRecognizer_tegra2.so'
+        exclude 'lib/arm64-v8a/libopencv_core.so'
+        exclude 'lib/arm64-v8a/libopencv_imgproc.so'
+        exclude 'lib/armeabi/libcardioDecider.so'
+        exclude 'lib/armeabi-v7a/libcardioDecider.so'
+        exclude 'lib/armeabi-v7a/libcardioRecognizer.so'
+        exclude 'lib/armeabi-v7a/libcardioRecognizer_tegra2.so'
+        exclude 'lib/armeabi-v7a/libopencv_core.so'
+        exclude 'lib/armeabi-v7a/libopencv_imgproc.so'
+        exclude 'lib/mips/libcardioDecider.so'
+        exclude 'lib/x86/libcardioDecider.so'
+        exclude 'lib/x86/libcardioRecognizer.so'
+        exclude 'lib/x86/libcardioRecognizer_tegra2.so'
+        exclude 'lib/x86/libopencv_core.so'
+        exclude 'lib/x86/libopencv_imgproc.so'
+        exclude 'lib/x86_64/libcardioDecider.so'
+        exclude 'lib/x86_64/libcardioRecognizer.so'
+        exclude 'lib/x86_64/libcardioRecognizer_tegra2.so'
+        exclude 'lib/x86_64/libopencv_core.so'
+        exclude 'lib/x86_64/libopencv_imgproc.so'
     }
     lintOptions {
         disable 'MissingTranslation'


### PR DESCRIPTION
Fixes #2426 
Changes: Remove useless native binaries from PayPal SDK

Screenshots for the change:
![Screenshot 2019-11-14 at 11 10 12 AM](https://user-images.githubusercontent.com/29139786/68829633-560e5c00-06cf-11ea-845c-dad32ca21b95.png)
