### PR TITLE
chore: cd to prev dir for fastlane metadata

### DIFF
--- a/scripts/update-apk.sh
+++ b/scripts/update-apk.sh
@@ -60,14 +60,18 @@ for file in app*; do
 done
 
 if $IS_PUBLISH_BRANCH ;then
+    # Move to previous directory so that fastlane metadata gets uploaded
+    cd ..
     gem install fastlane
-    fastlane supply --aab eventyay-attendee-master-app-playStore-release.aab --skip_upload_apk true --track alpha --json_key ../scripts/fastlane.json --package_name $PACKAGE_NAME $FASTLANE_DRY_RUN
+    fastlane supply --aab ./apk/eventyay-attendee-master-app-playStore-release.aab --skip_upload_apk true --track alpha --json_key ./scripts/fastlane.json --package_name $PACKAGE_NAME $FASTLANE_DRY_RUN
     if [[ $? -ne 0 ]]; then
         exit 1
     fi
     if $PR_FOR_RELEASE ;then
         exit 0
     fi
+    # Move back to apk directory so only apks get pushed to branch
+    cd apk
 fi
 
 # Create a new branch that will contains only latest apk


### PR DESCRIPTION
During the release process, metadata will not get 
uploaded if we are in apk directory
