### PR TITLE
fix: Hiding Keyboard on clicking anywhere on SignUp Fragment (#2507)

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/auth/SignUpFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/auth/SignUpFragment.kt
@@ -13,18 +13,7 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.navigation.Navigation.findNavController
 import androidx.navigation.fragment.navArgs
-import kotlinx.android.synthetic.main.fragment_signup.view.confirmPasswords
-import kotlinx.android.synthetic.main.fragment_signup.view.emailSignUp
-import kotlinx.android.synthetic.main.fragment_signup.view.firstNameText
-import kotlinx.android.synthetic.main.fragment_signup.view.lastNameText
-import kotlinx.android.synthetic.main.fragment_signup.view.passwordSignUp
-import kotlinx.android.synthetic.main.fragment_signup.view.signUpButton
-import kotlinx.android.synthetic.main.fragment_signup.view.signUpCheckbox
-import kotlinx.android.synthetic.main.fragment_signup.view.signUpText
-import kotlinx.android.synthetic.main.fragment_signup.view.signupNestedScrollView
-import kotlinx.android.synthetic.main.fragment_signup.view.textInputLayoutConfirmPassword
-import kotlinx.android.synthetic.main.fragment_signup.view.textInputLayoutPassword
-import kotlinx.android.synthetic.main.fragment_signup.view.toolbar
+import kotlinx.android.synthetic.main.fragment_signup.view.*
 import org.fossasia.openevent.general.R
 import org.fossasia.openevent.general.event.EVENT_DETAIL_FRAGMENT
 import org.fossasia.openevent.general.favorite.FAVORITE_FRAGMENT
@@ -66,6 +55,10 @@ class SignUpFragment : Fragment() {
         setToolbar(activity, show = false)
         rootView.toolbar.setNavigationOnClickListener {
             activity?.onBackPressed()
+        }
+
+        rootView.mainView.setOnClickListener{
+            hideSoftKeyboard(context, rootView.mainView)
         }
 
         rootView.signUpText.text = getTermsAndPolicyText(requireContext(), resources)

--- a/app/src/main/java/org/fossasia/openevent/general/auth/SignUpFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/auth/SignUpFragment.kt
@@ -57,7 +57,7 @@ class SignUpFragment : Fragment() {
             activity?.onBackPressed()
         }
 
-        rootView.mainView.setOnClickListener{
+        rootView.mainView.setOnClickListener {
             hideSoftKeyboard(context, rootView.mainView)
         }
 

--- a/app/src/main/res/layout/fragment_signup.xml
+++ b/app/src/main/res/layout/fragment_signup.xml
@@ -18,6 +18,7 @@
             app:navigationIcon="@drawable/ic_arrow_back_black"/>
 
     <LinearLayout
+        android:id="@+id/mainView"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/layout_margin_medium"


### PR DESCRIPTION
Fixes #2507 

Changes: Fixed, added hideSoftKeyboard()

Screenshots for the change:
Keyboard is hidden by clicking anywhere on the screen.
![20191216_033407](https://user-images.githubusercontent.com/42939575/70870265-17faa580-1fb7-11ea-917d-fdb0e70319dc.gif)
