### PR TITLE
fix: Resolve events UI bug

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/event/EventsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventsFragment.kt
@@ -118,6 +118,8 @@ class EventsFragment : Fragment(), BottomIconDoubleClick {
             .nonNull()
             .observe(viewLifecycleOwner, Observer { list ->
                 eventsListAdapter.submitList(list)
+                if (!rootView.shimmerEvents.isVisible)
+                    showEmptyMessage(eventsListAdapter.currentList?.isEmpty() ?: true)
             })
 
         eventsViewModel.progress
@@ -130,7 +132,6 @@ class EventsFragment : Fragment(), BottomIconDoubleClick {
                 } else {
                     rootView.shimmerEvents.stopShimmer()
                     rootView.swiperefresh.isRefreshing = false
-                    showEmptyMessage(eventsListAdapter.currentList?.isEmpty() ?: true)
                 }
                 rootView.shimmerEvents.isVisible = it
             })


### PR DESCRIPTION
Fixes #2480 

Changes: Instead of showing the message after the completion of the request, I am calling the show function after the recyclerview get populated.

Screenshots for the change:
![ezgif-2-68bfc5d23f78](https://user-images.githubusercontent.com/31654207/71234857-59c17e00-2320-11ea-92d7-48c4310c1d47.gif)