### PR TITLE
chore: bump com.diffplug.gradle.spotless from 3.26.1 to 3.27.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "com.diffplug.gradle.spotless" version "3.26.1"
+    id "com.diffplug.gradle.spotless" version "3.27.0"
 }
 
 apply plugin: 'com.android.application'

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,3 @@ allprojects {
         TRAVIS_BUILD = System.getenv("TRAVIS") == "true" && KEYSTORE_FILE.exists()
     }
 }
-
-task clean(type: Delete) {
-    delete rootProject.buildDir
-}


### PR DESCRIPTION
Fixes #2548 

Changes: Bump the version of com.diffplug.gradle.spotless from 3.26.1 to 3.27.0 and fix build errors
