### PR TITLE
chore: bump com.diffplug.gradle.spotless from 3.26.1 to 3.27.1

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "com.diffplug.gradle.spotless" version "3.26.1"
+    id "com.diffplug.gradle.spotless" version "3.27.1"
 }
 
 apply plugin: 'com.android.application'

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,3 @@ allprojects {
     }
 }
 
-task clean(type: Delete) {
-    delete rootProject.buildDir
-}


### PR DESCRIPTION
Fixes #2563 
Fixes #2600 

Changes: Bump the version of com.diffplug.gradle.spotless from 3.26.1 to 3.27.0 and fix build errors