### PR TITLE
fix: Scrolling in notification activity

### DIFF
--- a/app/src/main/res/layout/fragment_notification.xml
+++ b/app/src/main/res/layout/fragment_notification.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-
 <androidx.swiperefreshlayout.widget.SwipeRefreshLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
@@ -8,7 +7,7 @@
     android:id="@+id/swiperefresh"
     tools:context="org.fossasia.openevent.general.notification.NotificationFragment">
 
-    <androidx.coordinatorlayout.widget.CoordinatorLayout
+    <RelativeLayout
         android:id="@+id/notificationCoordinatorLayout"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
@@ -59,6 +58,7 @@
             android:layout_height="wrap_content"
             android:layout_gravity="center"
             android:gravity="center"
+            android:layout_centerInParent="true"
             android:orientation="vertical"
             android:visibility="gone">
 
@@ -78,7 +78,8 @@
             android:id="@+id/notificationRecycler"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:layout_marginTop="@dimen/logo_icon_width"/>
+            android:layout_below="@id/filterChipGroup"
+            android:layout_marginTop="@dimen/padding_extra_small"/>
 
-    </androidx.coordinatorlayout.widget.CoordinatorLayout>
+    </RelativeLayout>
 </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>

--- a/app/src/main/res/layout/fragment_notification.xml
+++ b/app/src/main/res/layout/fragment_notification.xml
@@ -7,8 +7,9 @@
     android:id="@+id/swiperefresh"
     tools:context="org.fossasia.openevent.general.notification.NotificationFragment">
 
-    <RelativeLayout
+    <LinearLayout
         android:id="@+id/notificationCoordinatorLayout"
+        android:orientation="vertical"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
@@ -55,10 +56,9 @@
         <LinearLayout
             android:id="@+id/noNotification"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
+            android:layout_height="match_parent"
             android:layout_gravity="center"
             android:gravity="center"
-            android:layout_centerInParent="true"
             android:orientation="vertical"
             android:visibility="gone">
 
@@ -78,8 +78,7 @@
             android:id="@+id/notificationRecycler"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:layout_below="@id/filterChipGroup"
             android:layout_marginTop="@dimen/padding_extra_small"/>
 
-    </RelativeLayout>
+    </LinearLayout>
 </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>


### PR DESCRIPTION
Fixes #2603 Scrolling in Notifivation Activity

Changes:
The List in Notifications were overlapping the chip group on the top of screen. I fixed it so there there must be some space between the chip group and the list items while scrolling.

Screenshots for the change:
![fix_notifications](https://user-images.githubusercontent.com/44086235/73134955-c5ef7a00-4062-11ea-995f-c9e786318e5d.gif)

