### PR TITLE
fix: made proper margin to no internet dialog

### DIFF
--- a/app/src/main/res/layout/fragment_events.xml
+++ b/app/src/main/res/layout/fragment_events.xml
@@ -110,6 +110,8 @@
                     app:layout_constraintLeft_toLeftOf="parent"
                     android:visibility="gone"
                     tools:visibility="visible"
+                    android:layout_marginLeft="@dimen/divider_margin_bottom"
+                    android:layout_marginRight="@dimen/divider_margin_bottom"
                     layout="@layout/content_no_internet" />
 
                 <com.facebook.shimmer.ShimmerFrameLayout


### PR DESCRIPTION
Fixes #2615 made proper margin to no internet dialog

Changes: 
Since there was no proper margins in the no internet dialog and also it was overlapping to the top of layout, so added proper margins so it look more like a dialog

Screenshots for the change:
![Screenshot_2020-01-31-00-09-17-829_com eventyay attendee](https://user-images.githubusercontent.com/44086235/73480048-25c98600-43bf-11ea-99d5-06ccca4b97ce.jpg)
