### PR TITLE
feat: Add skip and settings button to login page

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/auth/AuthFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/auth/AuthFragment.kt
@@ -147,7 +147,7 @@ class AuthFragment : Fragment(), ComplexBackPressFragment {
     }
 
     private fun redirectToLogin(email: String = "") {
-        findNavController(rootView).navigate(AuthFragmentDirections.actionAuthToLogIn(email, safeArgs.redirectedFrom),
+        findNavController(rootView).navigate(AuthFragmentDirections.actionAuthToLogIn(email, safeArgs.redirectedFrom, true),
             FragmentNavigatorExtras(rootView.email to "emailLoginTransition"))
     }
 

--- a/app/src/main/java/org/fossasia/openevent/general/auth/AuthFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/auth/AuthFragment.kt
@@ -147,7 +147,8 @@ class AuthFragment : Fragment(), ComplexBackPressFragment {
     }
 
     private fun redirectToLogin(email: String = "") {
-        findNavController(rootView).navigate(AuthFragmentDirections.actionAuthToLogIn(email, safeArgs.redirectedFrom, true),
+        findNavController(rootView).navigate(
+            AuthFragmentDirections.actionAuthToLogIn(email, safeArgs.redirectedFrom, true),
             FragmentNavigatorExtras(rootView.email to "emailLoginTransition"))
     }
 

--- a/app/src/main/java/org/fossasia/openevent/general/auth/LoginFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/auth/LoginFragment.kt
@@ -16,6 +16,9 @@ import kotlinx.android.synthetic.main.fragment_login.email
 import kotlinx.android.synthetic.main.fragment_login.loginButton
 import kotlinx.android.synthetic.main.fragment_login.password
 import kotlinx.android.synthetic.main.fragment_login.view.*
+import kotlinx.android.synthetic.main.fragment_login.view.email
+import kotlinx.android.synthetic.main.fragment_login.view.skipTextView
+import kotlinx.android.synthetic.main.fragment_login.view.toolbar
 import org.fossasia.openevent.general.BuildConfig
 import org.fossasia.openevent.general.PLAY_STORE_BUILD_FLAVOR
 import org.fossasia.openevent.general.R
@@ -71,6 +74,7 @@ class LoginFragment : Fragment() {
             hideSoftKeyboard(context, rootView)
         }
 
+        rootView.skipTextView.isVisible = safeArgs.showSkipButton
         rootView.skipTextView.setOnClickListener {
             findNavController(rootView).navigate(
                 LoginFragmentDirections.actionLoginToEventsPop()

--- a/app/src/main/java/org/fossasia/openevent/general/auth/LoginFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/auth/LoginFragment.kt
@@ -59,12 +59,22 @@ class LoginFragment : Fragment() {
             activity?.onBackPressed()
         }
 
+        rootView.settings.setOnClickListener {
+            findNavController(rootView).navigate(LoginFragmentDirections.actionLoginToSetting())
+        }
+
         if (loginViewModel.isLoggedIn())
             popBackStack()
 
         rootView.loginButton.setOnClickListener {
             loginViewModel.login(email.text.toString(), password.text.toString())
             hideSoftKeyboard(context, rootView)
+        }
+
+        rootView.skipTextView.setOnClickListener {
+            findNavController(rootView).navigate(
+                LoginFragmentDirections.actionLoginToEventsPop()
+            )
         }
 
         if (safeArgs.email.isNotEmpty()) {

--- a/app/src/main/res/layout/fragment_login.xml
+++ b/app/src/main/res/layout/fragment_login.xml
@@ -32,6 +32,14 @@
                     android:tint="@color/black"
                     android:visibility="gone"
                     app:srcCompat="@drawable/ic_check_black"/>
+                <ImageView
+                    android:id="@+id/settings"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="end"
+                    android:padding="@dimen/padding_large"
+                    android:tint="@color/black"
+                    android:src="@drawable/ic_settings"/>
             </androidx.appcompat.widget.Toolbar>
 
             <LinearLayout
@@ -107,9 +115,23 @@
                     android:layout_height="wrap_content"
                     android:textColor="@color/colorPrimary"
                     android:layout_marginTop="@dimen/padding_medium"
-                    android:layout_marginBottom="@dimen/padding_large"
                     android:padding="@dimen/padding_medium"
                     android:text="@string/forgot_password" />
+
+                <TextView
+                    android:id="@+id/skipTextView"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center_horizontal"
+                    android:layout_marginTop="@dimen/layout_margin_medium"
+                    android:textStyle="bold"
+                    android:background="?selectableItemBackground"
+                    android:padding="@dimen/padding_large"
+                    android:textColor="@android:color/holo_blue_light"
+                    android:text="@string/skip_for_now"
+                    android:layout_marginBottom="@dimen/padding_large"
+                    android:textSize="@dimen/text_size_medium"/>
+
 
             </LinearLayout>
 

--- a/app/src/main/res/navigation/navigation_graph.xml
+++ b/app/src/main/res/navigation/navigation_graph.xml
@@ -519,7 +519,7 @@
         <argument
             android:name="croppedImage"
             app:argType="string"
-            android:defaultValue=""/>
+            android:defaultValue="''"/>
     </fragment>
     <fragment
         android:id="@+id/cropImageFragment"
@@ -825,6 +825,13 @@
             app:destination="@id/eventsFragment"
             app:popUpTo="@id/eventsFragment"
             app:popUpToInclusive="true"/>
+        <action
+            android:id="@+id/action_login_to_setting"
+            app:destination="@id/settingsFragment"
+            app:popEnterAnim="@anim/slide_in_left"
+            app:popExitAnim="@anim/slide_out_right"
+            app:enterAnim="@anim/slide_in_right"
+            app:exitAnim="@anim/slide_out_left"/>
         <argument
             android:name="email"
             app:argType="string"
@@ -834,6 +841,10 @@
             android:name="redirectedFrom"
             app:argType="string"
             android:defaultValue="profile"/>
+        <argument
+            android:name="showSkipButton"
+            app:argType="boolean"
+            android:defaultValue="false" />
     </fragment>
     <fragment
         android:id="@+id/signUpFragment"


### PR DESCRIPTION
Fixes #2626 Add "Skip" and "Settings" button to login page

Changes: 
Added the settings and Skip button to the login page so if user wants to open settings after entering password or he change the mind to login without entering password then he can do so without going back to the previous page.

Screenshots for the change:

![Screenshot_2020-02-02-03-52-44-408_com eventyay attendee](https://user-images.githubusercontent.com/44086235/73600086-a03a0780-4571-11ea-9886-ecb61e5ba305.jpg)
![feat_skip-button](https://user-images.githubusercontent.com/44086235/73600087-a03a0780-4571-11ea-85a5-74959f4e3948.gif)
