### PR TITLE
chore(deps): bump stripe-android from 13.1.3 to 13.2.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -215,7 +215,7 @@ dependencies {
     implementation 'com.squareup.picasso:picasso:2.71828'
 
     // Stripe
-    implementation 'com.stripe:stripe-android:13.1.3'
+    implementation 'com.stripe:stripe-android:13.2.0'
 
     // QR Code
     implementation 'com.journeyapps:zxing-android-embedded:3.6.0'


### PR DESCRIPTION
Fixes #2630 build fail in upgrading dependency

chore(deps): bump stripe-android from 13.1.3 to 13.2.0

Changes: Updated the stripe-android dependency from 13.1.3 to 13.2.0