### PR TITLE
fix: Administrative area in Location Detection

### DIFF
--- a/app/src/fdroid/java/org/fossasia/openevent/general/search/location/GeoLocationViewModel.kt
+++ b/app/src/fdroid/java/org/fossasia/openevent/general/search/location/GeoLocationViewModel.kt
@@ -15,7 +15,7 @@ class GeoLocationViewModel(private val locationService: LocationService) : ViewM
     private val compositeDisposable = CompositeDisposable()
 
     fun configure() {
-        compositeDisposable += locationService.getAdministrativeArea()
+        compositeDisposable += locationService.getCityName()
             .subscribe({
                 mutableLocation.value = it
             }, {

--- a/app/src/main/java/org/fossasia/openevent/general/search/location/LocationService.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/search/location/LocationService.kt
@@ -11,4 +11,8 @@ interface LocationService {
      * Gives the administrative area of the current location the user is in.
      * */
     fun getAdministrativeArea(): Single<String>
+    /**
+     * Gives the city name of the current location the user is in.
+     * */
+    fun getCityName(): Single<String>
 }

--- a/app/src/playStore/java/org/fossasia/openevent/general/search/location/GeoLocationViewModel.kt
+++ b/app/src/playStore/java/org/fossasia/openevent/general/search/location/GeoLocationViewModel.kt
@@ -22,7 +22,7 @@ class GeoLocationViewModel(private val locationService: LocationService) : ViewM
     private val compositeDisposable = CompositeDisposable()
 
     fun configure() {
-        compositeDisposable += locationService.getAdministrativeArea()
+        compositeDisposable += locationService.getCityName()
             .subscribe(
                 { adminArea ->
                     mutableLocation.value = adminArea

--- a/app/src/playStore/java/org/fossasia/openevent/general/search/location/LocationServiceImpl.kt
+++ b/app/src/playStore/java/org/fossasia/openevent/general/search/location/LocationServiceImpl.kt
@@ -63,6 +63,46 @@ class LocationServiceImpl(
         }
     }
 
+    override fun getCityName(): Single<String> {
+        val locationManager = context.getSystemService(Context.LOCATION_SERVICE)
+
+        if (locationManager !is LocationManager) {
+            return Single.error(IllegalStateException())
+        }
+
+        if (!locationManager.isProviderEnabled(LocationManager.NETWORK_PROVIDER)) {
+            return Single.error(NoLocationSourceException())
+        }
+
+        val locationRequest = LocationRequest.create().apply {
+            priority = LocationRequest.PRIORITY_LOW_POWER
+        }
+        return Single.create { emitter ->
+            try {
+                LocationServices
+                    .getFusedLocationProviderClient(context)
+                    .requestLocationUpdates(locationRequest, object : LocationCallback() {
+
+                        override fun onLocationResult(locationResult: LocationResult?) {
+                            if (locationResult == null) {
+                                emitter.onError(IllegalStateException())
+                                return
+                            }
+                            try {
+                                val locality = locationResult.getLocality()
+                                emitter.onSuccess(locality)
+                            } catch (e: Exception) {
+                                Timber.e(e, "Error finding user current location")
+                                emitter.onSuccess(resource.getString(R.string.no_location).nullToEmpty())
+                            }
+                        }
+                    }, null)
+            } catch (e: SecurityException) {
+                emitter.onError(LocationPermissionException())
+            }
+        }
+    }
+
     private fun LocationResult.getAdminArea(): String {
         locations.filterNotNull().forEach { location ->
             val latitude = location.latitude
@@ -73,6 +113,24 @@ class LocationServiceImpl(
                 val addresses = geocoder.getFromLocation(latitude, longitude, maxResults)
                 val address = addresses.first { address -> address.adminArea != null }
                 return address.adminArea
+            } catch (exception: IOException) {
+                Timber.e(exception, "Error Fetching Location")
+                throw IllegalArgumentException()
+            }
+        }
+        throw IllegalArgumentException()
+    }
+
+    private fun LocationResult.getLocality(): String {
+        locations.filterNotNull().forEach { location ->
+            val latitude = location.latitude
+            val longitude = location.longitude
+            try {
+                val maxResults = 2
+                val geocoder = Geocoder(context, Locale.getDefault())
+                val addresses = geocoder.getFromLocation(latitude, longitude, maxResults)
+                val address = addresses.first { address -> address.locality != null }
+                return address.locality
             } catch (exception: IOException) {
                 Timber.e(exception, "Error Fetching Location")
                 throw IllegalArgumentException()


### PR DESCRIPTION
Fixes #2459 The location is not displayed properly

Changes: 
Previously on clicking on detect my location it showed the Administrative Area made it to display the City Name as it would be more specific.

Screenshots for the change:

**Previously**
![loc_prev](https://user-images.githubusercontent.com/44086235/73777386-53dc0b00-47af-11ea-8a6a-23090efb1b37.gif)

**After Changing**
 ![loc_new](https://user-images.githubusercontent.com/44086235/73777388-53dc0b00-47af-11ea-8fad-19517c49c4eb.gif)
