### PR TITLE
fix: Edit Profile Crashing and ScrollView in signup resolved

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,7 +21,7 @@
         android:theme="@style/AppTheme">
         <activity
             android:name=".MainActivity"
-            android:windowSoftInputMode="adjustPan"
+            android:windowSoftInputMode="adjustResize"
             android:theme="@style/SplashTheme">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/org/fossasia/openevent/general/MainActivity.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/MainActivity.kt
@@ -17,6 +17,7 @@ import org.fossasia.openevent.general.utils.AppLinkUtils
 import org.fossasia.openevent.general.utils.Utils.navAnimGone
 import org.fossasia.openevent.general.utils.Utils.navAnimVisible
 import org.jetbrains.anko.design.snackbar
+import org.koin.androidx.scope.BuildConfig
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
 const val PLAY_STORE_BUILD_FLAVOR = "playStore"

--- a/app/src/main/java/org/fossasia/openevent/general/auth/EditProfileFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/auth/EditProfileFragment.kt
@@ -208,7 +208,7 @@ class EditProfileFragment : Fragment(), ComplexBackPressFragment {
         userTwitter = user.twitterUrl.nullToEmpty()
         userInstagram = user.instagramUrl.nullToEmpty()
 
-        if (safeArgs.croppedImage.isEmpty()) {
+        if (safeArgs.croppedImage.equals("''")) {
             if (!editProfileViewModel.userAvatar.isNullOrEmpty() && !editProfileViewModel.avatarUpdated) {
                 val drawable = requireDrawable(requireContext(), R.drawable.ic_account_circle_grey)
                 Picasso.get()

--- a/app/src/main/java/org/fossasia/openevent/general/utils/ImageUtils.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/utils/ImageUtils.kt
@@ -15,7 +15,7 @@ object ImageUtils {
     }
 
     fun decodeBitmap(encodedBitmap: String): Bitmap {
-        val decodedString = Base64.decode(encodedBitmap, Base64.DEFAULT)
+        val decodedString = Base64.decode(encodedBitmap, Base64.DEFAULT or Base64.NO_WRAP)
         return BitmapFactory.decodeByteArray(decodedString, 0, decodedString.size)
     }
 }


### PR DESCRIPTION
Fixes #2660 and #2609 

Changes: 1) added extra param ,Base64.NoWrap,in decodeBitmap of ImageUtils and also modifying the if condition in EditProfileFragment wrt issue #2660 
                2) changed the value of  windowSoftInputMode to "adjustResize" wrt to issue #2609 

Screenshots for the change:
Before:
![Screenshot_2020-06-16-15-31-59-26](https://user-images.githubusercontent.com/43871890/84761549-30d82800-afe7-11ea-9a2f-20ba338ac763.png)

After:(Scroll View being enabled when softkeyboard pops up)
![Screenshot_2020-06-16-15-34-37-76](https://user-images.githubusercontent.com/43871890/84761582-3cc3ea00-afe7-11ea-8a53-51ea5458cabf.png)

After: (Edit Profile opens up without crashing)
![Screenshot_2020-06-16-15-34-15-64](https://user-images.githubusercontent.com/43871890/84761604-45b4bb80-afe7-11ea-88d4-d942fa758ecb.png)