### PR TITLE
fix: Fixed the UI glitch that happens when the events fragment is refreshed.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,10 @@ cache:
       - "${TRAVIS_BUILD_DIR}/gradle/wrapper/dists/"
       - "$HOME/.gradle/caches/"
       - "$HOME/.gradle/wrapper/"
+
+licenses:
+  - '.+'
+
 before_script:
   - bash scripts/prep-key.sh
 script:
@@ -25,7 +29,9 @@ script:
 after_success:
     - bash scripts/update-apk.sh
 
+
 branches:
   only:
     - master
     - development
+

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,6 +18,7 @@ android {
     dataBinding {
         enabled = true
 
+
     }
     compileSdkVersion 28
     defaultConfig {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,6 +17,7 @@ def LOCAL_KEY_PRESENT = project.hasProperty('SIGNING_KEY_FILE') && rootProject.f
 android {
     dataBinding {
         enabled = true
+
     }
     compileSdkVersion 28
     defaultConfig {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -25,8 +25,8 @@ android {
         applicationId "com.eventyay.attendee"
         minSdkVersion 21
         targetSdkVersion 28
-        versionCode 17
-        versionName "0.9.1"
+        versionCode 18
+        versionName "0.9.2"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true
         multiDexEnabled true

--- a/app/src/main/java/org/fossasia/openevent/general/MainActivity.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/MainActivity.kt
@@ -3,6 +3,7 @@ package org.fossasia.openevent.general
 import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
+import android.util.Log
 import androidx.appcompat.app.AppCompatActivity
 import androidx.navigation.NavController
 import androidx.navigation.fragment.NavHostFragment
@@ -31,10 +32,10 @@ class MainActivity : AppCompatActivity() {
         setTheme(R.style.AppTheme)
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
-
         val hostFragment = supportFragmentManager.findFragmentById(R.id.frameContainer)
         if (hostFragment is NavHostFragment)
             navController = hostFragment.navController
+
         setupBottomNavigationMenu(navController)
 
         navController.addOnDestinationChangedListener { _, destination, _ ->

--- a/app/src/main/java/org/fossasia/openevent/general/event/EventsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventsFragment.kt
@@ -201,14 +201,13 @@ class EventsFragment : Fragment(), BottomIconDoubleClick {
         rootView.swiperefresh.setColorSchemeColors(Color.BLUE)
         rootView.swiperefresh.setOnRefreshListener {
             showNoInternetScreen(!eventsViewModel.isConnected())
-          eventsViewModel.clearEvents()
+            eventsViewModel.clearEvents()
             eventsViewModel.clearLastSearch()
-                if (eventsViewModel.isConnected()) {
-                    eventsViewModel.loadLocationEvents()
-                } else {
-                    showNoInternetScreen(true)
-                }
-
+            if (!eventsViewModel.isConnected()) {
+                rootView.swiperefresh.isRefreshing = false
+            } else {
+                eventsViewModel.loadLocationEvents()
+            }
         }
 
         startupViewModel.isRefresh

--- a/app/src/main/java/org/fossasia/openevent/general/event/EventsFragment.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventsFragment.kt
@@ -4,6 +4,7 @@ import android.graphics.Color
 import android.os.Bundle
 import android.text.Editable
 import android.text.TextWatcher
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -53,6 +54,7 @@ import org.fossasia.openevent.general.utils.extensions.setStartPostponedEnterTra
 import org.fossasia.openevent.general.utils.extensions.showWithFading
 import org.jetbrains.anko.design.longSnackbar
 import org.koin.androidx.viewmodel.ext.android.viewModel
+import timber.log.Timber
 
 const val BEEN_TO_WELCOME_SCREEN = "beenToWelcomeScreen"
 const val EVENTS_FRAGMENT = "eventsFragment"
@@ -81,6 +83,7 @@ class EventsFragment : Fragment(), BottomIconDoubleClick {
         val progressDialog = progressDialog(context, getString(R.string.loading_message))
 
         val token = arguments?.getString(RESET_PASSWORD_TOKEN)
+
         if (token != null)
             showResetPasswordAlertDialog(token)
 
@@ -116,10 +119,8 @@ class EventsFragment : Fragment(), BottomIconDoubleClick {
 
         eventsViewModel.pagedEvents
             .nonNull()
-            .observe(viewLifecycleOwner, Observer { list ->
-                eventsListAdapter.submitList(list)
-                if (!rootView.shimmerEvents.isVisible)
-                    showEmptyMessage(eventsListAdapter.currentList?.isEmpty() ?: true)
+            .observe( viewLifecycleOwner, Observer {
+                eventsListAdapter.submitList(it)
             })
 
         eventsViewModel.progress
@@ -130,6 +131,12 @@ class EventsFragment : Fragment(), BottomIconDoubleClick {
                     showEmptyMessage(false)
                     showNoInternetScreen(false)
                 } else {
+                    if(eventsListAdapter.currentList?.isEmpty() != false ){
+                        showEmptyMessage(true)
+                    }
+                    else{
+                        showEmptyMessage(false)
+                    }
                     rootView.shimmerEvents.stopShimmer()
                     rootView.swiperefresh.isRefreshing = false
                 }
@@ -146,6 +153,7 @@ class EventsFragment : Fragment(), BottomIconDoubleClick {
         rootView.notificationToolbar.isVisible = eventsViewModel.isLoggedIn()
 
         eventsViewModel.loadLocation()
+
         if (rootView.locationTextView.text == getString(R.string.enter_location)) {
             rootView.emptyEventsText.text = getString(R.string.choose_preferred_location_message)
         } else {
@@ -193,13 +201,14 @@ class EventsFragment : Fragment(), BottomIconDoubleClick {
         rootView.swiperefresh.setColorSchemeColors(Color.BLUE)
         rootView.swiperefresh.setOnRefreshListener {
             showNoInternetScreen(!eventsViewModel.isConnected())
-            eventsViewModel.clearEvents()
+          eventsViewModel.clearEvents()
             eventsViewModel.clearLastSearch()
-            if (!eventsViewModel.isConnected()) {
-                rootView.swiperefresh.isRefreshing = false
-            } else {
-                eventsViewModel.loadLocationEvents()
-            }
+                if (eventsViewModel.isConnected()) {
+                    eventsViewModel.loadLocationEvents()
+                } else {
+                    showNoInternetScreen(true)
+                }
+
         }
 
         startupViewModel.isRefresh

--- a/app/src/main/java/org/fossasia/openevent/general/event/EventsViewModel.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventsViewModel.kt
@@ -81,7 +81,7 @@ class EventsViewModel(
                 val currentPagedEvents = mutablePagedEvents.value
                 if (currentPagedEvents == null) {
                     mutablePagedEvents.value = it
-              } else {
+                } else {
                     currentPagedEvents.addAll(it)
                     mutablePagedEvents.value = currentPagedEvents
                 }

--- a/app/src/main/java/org/fossasia/openevent/general/event/EventsViewModel.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventsViewModel.kt
@@ -1,5 +1,6 @@
 package org.fossasia.openevent.general.event
 
+import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
@@ -21,6 +22,7 @@ import org.fossasia.openevent.general.favorite.FavoriteEvent
 import org.fossasia.openevent.general.search.location.SAVED_LOCATION
 import org.fossasia.openevent.general.utils.extensions.withDefaultSchedulers
 import timber.log.Timber
+import java.lang.NullPointerException
 
 const val NEW_NOTIFICATIONS = "newNotifications"
 
@@ -34,7 +36,6 @@ class EventsViewModel(
 ) : ViewModel() {
 
     private val compositeDisposable = CompositeDisposable()
-
     val connection: LiveData<Boolean> = mutableConnectionLiveData
     private val mutableProgress = MediatorLiveData<Boolean>()
     val progress: MediatorLiveData<Boolean> = mutableProgress
@@ -56,10 +57,11 @@ class EventsViewModel(
         val location = mutableSavedLocation.value
         if (location == null || location == resource.getString(R.string.enter_location) ||
             location == resource.getString(R.string.no_location)) {
+           Timber.d("set progress to false")
             mutableProgress.value = false
             return
         }
-
+        Timber.d(location+"this is the location")
         sourceFactory = EventsDataSourceFactory(
             compositeDisposable,
             eventService,
@@ -81,7 +83,8 @@ class EventsViewModel(
                 val currentPagedEvents = mutablePagedEvents.value
                 if (currentPagedEvents == null) {
                     mutablePagedEvents.value = it
-                } else {
+              } else {
+                    Timber.d(it.toString()+"in else viewmodel")
                     currentPagedEvents.addAll(it)
                     mutablePagedEvents.value = currentPagedEvents
                 }
@@ -89,6 +92,7 @@ class EventsViewModel(
                 Timber.e(it, "Error fetching events")
                 mutableMessage.value = resource.getString(R.string.error_fetching_events_message)
             })
+
     }
     fun isConnected(): Boolean = mutableConnectionLiveData.value ?: false
 

--- a/app/src/main/java/org/fossasia/openevent/general/event/EventsViewModel.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/EventsViewModel.kt
@@ -57,11 +57,9 @@ class EventsViewModel(
         val location = mutableSavedLocation.value
         if (location == null || location == resource.getString(R.string.enter_location) ||
             location == resource.getString(R.string.no_location)) {
-           Timber.d("set progress to false")
             mutableProgress.value = false
             return
         }
-        Timber.d(location+"this is the location")
         sourceFactory = EventsDataSourceFactory(
             compositeDisposable,
             eventService,
@@ -84,7 +82,6 @@ class EventsViewModel(
                 if (currentPagedEvents == null) {
                     mutablePagedEvents.value = it
               } else {
-                    Timber.d(it.toString()+"in else viewmodel")
                     currentPagedEvents.addAll(it)
                     mutablePagedEvents.value = currentPagedEvents
                 }

--- a/app/src/main/java/org/fossasia/openevent/general/event/paging/EventsDataSource.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/paging/EventsDataSource.kt
@@ -43,9 +43,11 @@ class EventsDataSource(
             eventService.getEventsByLocationPaged(query, requestedPage)
                 .withDefaultSchedulers()
                 .subscribe({ response ->
-                    if (response.isEmpty()) mutableProgress.value = false
                     initialCallback?.onResult(response, null, adjacentPage)
                     callback?.onResult(response, adjacentPage)
+                    if (response.isEmpty()) {
+                        mutableProgress.value = false
+                    }
                 }, { error ->
                     Timber.e(error, "Fail on fetching page of events")
                 }

--- a/app/src/main/java/org/fossasia/openevent/general/utils/AppLinkUtils.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/utils/AppLinkUtils.kt
@@ -29,5 +29,6 @@ object AppLinkUtils {
         val bundle = Bundle()
         bundle.putString(data.argumentKey, data.argumentValue)
         navController.navigate(data.destinationId, bundle)
+
     }
 }

--- a/app/src/main/res/layout/fragment_events.xml
+++ b/app/src/main/res/layout/fragment_events.xml
@@ -145,7 +145,7 @@
                     app:layout_constraintTop_toTopOf="parent"
                     app:layout_constraintBottom_toBottomOf="parent"
                     android:visibility="gone"
-                    tools:visibility="visible">
+                    tools:visibility="invisible">
                     <RelativeLayout
                         android:layout_width="@dimen/item_image_view_large"
                         android:layout_height="@dimen/item_image_view_large"

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.3'
+        classpath 'com.android.tools.build:gradle:4.0.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'android.arch.navigation:navigation-safe-args-gradle-plugin:1.0.0'
         classpath "gradle.plugin.com.github.b3er.local.properties:local-properties-plugin:1.1"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon May 11 23:14:47 IST 2020
+#Mon Oct 05 18:27:13 IST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip


### PR DESCRIPTION
Fixes #2786 

Changes: 
Now , on refresh , events are loaded right after the shimmer without the no-event placeholder coming in .

