### PR TITLE
fix: Favourite fragment loading glitch.

### DIFF
--- a/app/src/main/java/org/fossasia/openevent/general/event/paging/EventsDataSource.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/paging/EventsDataSource.kt
@@ -46,7 +46,6 @@ class EventsDataSource(
                     if (response.isEmpty()) mutableProgress.value = false
                     initialCallback?.onResult(response, null, adjacentPage)
                     callback?.onResult(response, adjacentPage)
-
                 }, { error ->
                     Timber.e(error, "Fail on fetching page of events")
                 }

--- a/app/src/main/java/org/fossasia/openevent/general/event/paging/EventsDataSource.kt
+++ b/app/src/main/java/org/fossasia/openevent/general/event/paging/EventsDataSource.kt
@@ -46,6 +46,7 @@ class EventsDataSource(
                     if (response.isEmpty()) mutableProgress.value = false
                     initialCallback?.onResult(response, null, adjacentPage)
                     callback?.onResult(response, adjacentPage)
+
                 }, { error ->
                     Timber.e(error, "Fail on fetching page of events")
                 }

--- a/app/src/main/res/layout/fragment_favorite.xml
+++ b/app/src/main/res/layout/fragment_favorite.xml
@@ -49,7 +49,6 @@
                 android:id="@+id/favoriteProgressBar"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:visibility="gone"
                 app:layout_constraintLeft_toLeftOf="parent"
                 app:layout_constraintRight_toRightOf="parent"
                 app:layout_constraintTop_toTopOf="parent"
@@ -76,6 +75,7 @@
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_vertical"
                 android:orientation="vertical"
+                android:visibility="invisible"
                 app:layout_constraintTop_toTopOf="parent"
                 app:layout_constraintBottom_toBottomOf="parent">
 


### PR DESCRIPTION
Fixes #2791 

Changes: Made the changes to meet the expected behavior i.e displaying
![ezgif com-gif-maker (1)](https://user-images.githubusercontent.com/59550525/96152062-bc2be080-0f29-11eb-9c94-452fa71fc289.gif)
. Progress bar before the items are fetched.

Screenshots for the change: